### PR TITLE
search and pagination

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-#DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment
+DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,61 @@
+import type { NextRequest } from "next/server";
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
+import { asc, count, or, ilike, sql } from "drizzle-orm";
+import { advocateData } from "@/db/seed/advocates";
 
-export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
+export async function GET(req: NextRequest) {
+  const searchTerm = req.nextUrl?.searchParams.get("searchTerm");
+  const limit = req.nextUrl?.searchParams.get("limit");
+  const offset = req.nextUrl?.searchParams.get("offset");
 
-  const data = advocateData;
+  if (!db) {
+    const data = searchTerm
+      ? advocateData.filter((advocate) => {
+          return (
+            advocate.firstName.includes(searchTerm) ||
+            advocate.lastName.includes(searchTerm) ||
+            advocate.city.includes(searchTerm) ||
+            advocate.degree.includes(searchTerm) ||
+            advocate.specialties.includes(searchTerm)
+          );
+        })
+      : advocateData;
 
-  return Response.json({ data });
+    return Response.json({
+      data: {
+        advocates: data.slice(Number(offset), Number(offset) + Number(limit)),
+        totalCount: data.length,
+      },
+    });
+  }
+
+  const advocatesData = await db
+    .select()
+    .from(advocates)
+    .where(
+      searchTerm
+        ? or(
+            ilike(advocates.firstName, `%${searchTerm}%`),
+            ilike(advocates.lastName, `%${searchTerm}%`),
+            ilike(advocates.city, `%${searchTerm}%`),
+            ilike(advocates.degree, `%${searchTerm}%`),
+            sql`${advocates.specialties}::text ILIKE ${`%${searchTerm}%`}`
+          )
+        : undefined
+    )
+    .orderBy(asc(advocates.id))
+    .limit(Number(limit))
+    .offset(Number(offset));
+
+  const advocatesTotalCount = await db
+    .select({ count: count() })
+    .from(advocates);
+
+  return Response.json({
+    data: {
+      advocates: advocatesData,
+      totalCount: advocatesTotalCount[0].count,
+    },
+  });
 }

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -3,6 +3,10 @@ import { advocates } from "../../../db/schema";
 import { advocateData } from "../../../db/seed/advocates";
 
 export async function POST() {
+  if (!db) {
+    return;
+  }
+
   const records = await db.insert(advocates).values(advocateData).returning();
 
   return Response.json({ advocates: records });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,45 +1,21 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useDebounce } from "@/util/hooks/useDebounce";
+import { useFetchAdvocates } from "@/util/hooks/useFetchAdvocates";
+import { useState } from "react";
+
+const LIMIT = 10;
 
 export default function Home() {
-  const [advocates, setAdvocates] = useState([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState([]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const debouncedSearchTerm = useDebounce(searchTerm, 1);
 
-  useEffect(() => {
-    console.log("fetching advocates...");
-    fetch("/api/advocates").then((response) => {
-      response.json().then((jsonResponse) => {
-        setAdvocates(jsonResponse.data);
-        setFilteredAdvocates(jsonResponse.data);
-      });
-    });
-  }, []);
-
-  const onChange = (e) => {
-    const searchTerm = e.target.value;
-
-    document.getElementById("search-term").innerHTML = searchTerm;
-
-    console.log("filtering advocates...");
-    const filteredAdvocates = advocates.filter((advocate) => {
-      return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
-      );
-    });
-
-    setFilteredAdvocates(filteredAdvocates);
-  };
-
-  const onClick = () => {
-    console.log(advocates);
-    setFilteredAdvocates(advocates);
-  };
+  const [page, setPage] = useState(0);
+  const { advocates, totalCount } = useFetchAdvocates(
+    LIMIT,
+    page * LIMIT,
+    debouncedSearchTerm
+  );
 
   return (
     <main style={{ margin: "24px" }}>
@@ -48,35 +24,38 @@ export default function Home() {
       <br />
       <div>
         <p>Search</p>
-        <p>
-          Searching for: <span id="search-term"></span>
-        </p>
-        <input style={{ border: "1px solid black" }} onChange={onChange} />
-        <button onClick={onClick}>Reset Search</button>
+        <input
+          style={{ border: "1px solid black" }}
+          onChange={(e) => setSearchTerm(e.target.value)}
+        />
       </div>
       <br />
       <br />
       <table>
         <thead>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>City</th>
-          <th>Degree</th>
-          <th>Specialties</th>
-          <th>Years of Experience</th>
-          <th>Phone Number</th>
+          <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>City</th>
+            <th>Degree</th>
+            <th>Specialties</th>
+            <th>Years of Experience</th>
+            <th>Phone Number</th>
+          </tr>
         </thead>
         <tbody>
-          {filteredAdvocates.map((advocate) => {
+          {advocates.map((advocate) => {
             return (
-              <tr>
+              <tr
+                key={`advocate-table-row-${advocate.firstName}-${advocate.lastName}`}
+              >
                 <td>{advocate.firstName}</td>
                 <td>{advocate.lastName}</td>
                 <td>{advocate.city}</td>
                 <td>{advocate.degree}</td>
                 <td>
-                  {advocate.specialties.map((s) => (
-                    <div>{s}</div>
+                  {advocate.specialties?.map((s) => (
+                    <div key={`advocate-speciality-${s}`}>{s}</div>
                   ))}
                 </td>
                 <td>{advocate.yearsOfExperience}</td>
@@ -86,6 +65,29 @@ export default function Home() {
           })}
         </tbody>
       </table>
+      <div>
+        {totalCount > 0
+          ? Array(Math.ceil(totalCount / LIMIT))
+              .fill("")
+              .map((_, index) => {
+                return (
+                  <button
+                    onClick={() => {
+                      setPage(index);
+                    }}
+                    style={{
+                      width: "50px",
+                      border: "1px solid black",
+                      backgroundColor: page === index ? "gray" : "",
+                    }}
+                    key={`pagination-button-${index}`}
+                  >
+                    {index + 1}
+                  </button>
+                );
+              })
+          : null}
+      </div>
     </main>
   );
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -4,11 +4,7 @@ import postgres from "postgres";
 const setup = () => {
   if (!process.env.DATABASE_URL) {
     console.error("DATABASE_URL is not set");
-    return {
-      select: () => ({
-        from: () => [],
-      }),
-    };
+    return null;
   }
 
   // for query purposes

--- a/src/util/hooks/useDebounce.ts
+++ b/src/util/hooks/useDebounce.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce(cb: string, delay: number): string {
+  const [debounceValue, setDebounceValue] = useState(cb);
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebounceValue(cb);
+    }, delay * 1000);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [cb, delay]);
+  return debounceValue;
+}

--- a/src/util/hooks/useFetchAdvocates.ts
+++ b/src/util/hooks/useFetchAdvocates.ts
@@ -1,0 +1,29 @@
+import { useMemo, useState } from "react";
+import { ADVOCATE } from "../types";
+
+export function useFetchAdvocates(
+  limit: number,
+  offset: number,
+  searchTerm?: string
+): { advocates: ADVOCATE[]; totalCount: number } {
+  const [advocates, setAdvocates] = useState<ADVOCATE[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+
+  useMemo(() => {
+    fetch(
+      "/api/advocates?" +
+        new URLSearchParams({
+          limit: limit.toString(),
+          offset: offset.toString(),
+          searchTerm: searchTerm ?? "",
+        })
+    ).then((response) => {
+      response.json().then((jsonResponse) => {
+        setAdvocates(jsonResponse.data.advocates);
+        setTotalCount(Number(jsonResponse.data.totalCount));
+      });
+    });
+  }, [searchTerm, limit, offset]);
+
+  return { advocates, totalCount };
+}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,0 +1,9 @@
+export type ADVOCATE = {
+  firstName: string;
+  lastName: string;
+  city: string;
+  degree: string;
+  specialties: string[];
+  yearsOfExperience: string;
+  phoneNumber: string;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
This PR makes two main improvements:

1. adds pagination
2. moves search functionality from the frontend to the backend (and to the database when one is available)

These changes are necessary because of the size of the dataset. It isn't practical for the client to fetch hundreds of thousands of records from the backend so it needs to fetch only a subset, and search functionality affects which records are returned, so both search and pagination need to be handled by the backend.

I wanted to automatically search when the user adds a term, so I added a debounce to prevent sending requests to the server while the user is in the middle of typing their term and removed the now-unnecessary button. I also added the "search term" to the React state and removed the `innerHTML` reference, and fixed the document structure / added keys to remove any errors from the console.

My dev environment was really unhappy with the "bundler" module resolution, and the return type of the `db/index.ts` file was giving me a really hard time so I just made quick changes; in a real setting I would be way more cautious with these types of changes though.